### PR TITLE
Add a github action for lint testing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,29 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-rc.1
+        with:
+          command: lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-alpha.3
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-rc.1
+        with:
+          command: install

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,16 +14,19 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0-rc.1
+        uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
           command: lint
+          config: ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
-        # Only build a kind cluster if there are chart changes to test.
+        uses: helm/kind-action@v1.0.0-rc.1
+        with:
+          install_local_path_provisioner: true
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-rc.1
+        uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
           command: install
+          config: ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Install Helm
+        run: |
+          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0-rc.2
+        with:
+          charts_repo_url: https://jarretlavallee.github.io/helm-charts/
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ This repo contains various helm charts that I use in my lab. None are ready for 
 ## Usage
 
 Helm v3 is required to run the charts. Please refer to the [documentation](https://helm.sh/docs/) to get started.
+
+```
+helm repo add jarretlavallee https://jarretlavallee.github.io/helm-charts/
+helm repo update
+```

--- a/charts/cd4pe/README.md
+++ b/charts/cd4pe/README.md
@@ -8,10 +8,9 @@ CD4PE with PostgreSQL for a deployment in a lab. This is not suited for producti
 
 Supported for Helm v3
 
-\#TODO add installation instructions.
-
 ```bash
-helm install cd4pe
+helm repo add jarretlavallee https://jarretlavallee.github.io/helm-charts/
+helm install jarretlavallee/cd4pe 
 ```
 
 ## Introduction
@@ -27,10 +26,9 @@ This chart bootstraps a lab instance of [CD4PE](hhttps://puppet.com/docs/continu
 
 To install the chart with the release name `my-release`:
 
-\#TODO add installation instructions.
 
 ```bash
-helm install --name my-release
+helm install --name my-release jarretlavallee/cd4pe 
 ```
 
 The command deploys CD4PE on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -87,11 +85,10 @@ The above parameters map to the env variables defined in each container. For mor
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
-\#TODO add installation instructions.
-
 ```bash
 helm install --name CD4PE-release \
-  --set service.type=LoadBalancer
+  --set service.type=LoadBalancer \
+  jarretlavallee/cd4pe
 ```
 
 The above command sets the  by CD4PE service to LoadBalancer, so all of the services will be on the same external IP.
@@ -99,7 +96,7 @@ The above command sets the  by CD4PE service to LoadBalancer, so all of the serv
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```bash
-helm install --name my-release -f values.yaml
+helm install --name my-release -f values.yaml jarretlavallee/cd4pe
 ```
 
 ## Persistence

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,6 @@
+helm-extra-args: --timeout 600s
+chart-dirs:
+  - charts
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
+  - stable=https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
This commit adds a github action to lint test helm charts. It will spin
up a kubernetes in docker cluster and test changes to the charts.