### PR TITLE
Add the option for a sidecar

### DIFF
--- a/charts/cd4pe/Chart.yaml
+++ b/charts/cd4pe/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: cd4pe
 description: An experimental helm chart for Puppet CD4PE
+home: https://github.com/jarretlavallee/helm-charts
+maintainers:
+  - name: jarretlavallee
+    email: jarret.lavallee@gmail.com
 
 type: application
 version: 0.1.1

--- a/charts/cd4pe/Chart.yaml
+++ b/charts/cd4pe/Chart.yaml
@@ -3,8 +3,8 @@ name: cd4pe
 description: An experimental helm chart for Puppet CD4PE
 
 type: application
-version: 0.1.0
-appVersion: 3.7.1
+version: 0.1.1
+appVersion: 3.8.0
 
 dependencies:
   - name: postgresql

--- a/charts/cd4pe/README.md
+++ b/charts/cd4pe/README.md
@@ -10,7 +10,7 @@ Supported for Helm v3
 
 ```bash
 helm repo add jarretlavallee https://jarretlavallee.github.io/helm-charts/
-helm install jarretlavallee/cd4pe 
+helm install jarretlavallee/cd4pe
 ```
 
 ## Introduction
@@ -26,9 +26,8 @@ This chart bootstraps a lab instance of [CD4PE](hhttps://puppet.com/docs/continu
 
 To install the chart with the release name `my-release`:
 
-
 ```bash
-helm install --name my-release jarretlavallee/cd4pe 
+helm install --name my-release jarretlavallee/cd4pe
 ```
 
 The command deploys CD4PE on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -80,6 +79,7 @@ The following table lists the configurable parameters of the CD4PE chart and the
 | `postgresql.postgresqlDatabase`    | The database name to create and use for cd4pe                           | `cd4pe`                                                                                                                             |
 | `postgresql.postgresqlUsername`    | The user name to use to access PostgreSQL                               | `cd4pe`                                                                                                                             |
 | `postgresql.postgresqlPassword`    | The password to use to access PostgreSQL                                | A random 10 character string                                                                                                        |
+| `sidecars`                         | An array of any sidecars to run along with CD4PE                        | `[]`                                                                                                                                |
 
 The above parameters map to the env variables defined in each container. For more information please refer to each image documentation.
 

--- a/charts/cd4pe/templates/deployment.yaml
+++ b/charts/cd4pe/templates/deployment.yaml
@@ -91,6 +91,9 @@ spec:
           - name: object-store
             mountPath: {{ .Values.persistence.mountPath }}
           {{- end }}
+        {{- if .Values.sidecars}}
+        {{ toYaml .Values.sidecars | nindent 8 }}
+        {{- end }} 
       {{- if .Values.persistence.enabled }}
       volumes:
       - name: object-store

--- a/charts/cd4pe/templates/tests/test-connection.yaml
+++ b/charts/cd4pe/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "cd4pe.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "cd4pe.fullname" . }}:{{ (index .Values.service.ports 0).port }}']
   restartPolicy: Never

--- a/charts/cd4pe/values.yaml
+++ b/charts/cd4pe/values.yaml
@@ -96,6 +96,16 @@ postgresql:
   postgresqlUsername: "cd4pe"
   # postgresqlPassword can be set or a random password is generate and used
 
+# Inject sidecar containers if desired.
+sidecars: []
+  ## The example below runs the client for https://smee.io as sidecar container next to cd4pe,
+  ## that allows to trigger build behind a firewall.
+  ## https://jenkins.io/blog/2019/01/07/webhook-firewalls/#triggering-builds-with-webhooks-behind-a-secure-firewall
+  ##
+  ## Note: To use it you should go to https://smee.io/new and update the url to the generete one.
+  # - name: smee
+  #   image: twalter/smee-client:latest
+  #   args: ["--port", "8000", "--path", "/gitlab/push", "--url", "https://smee.io/new"]
 
 podAnnotations: {}
 

--- a/charts/cd4pe/values.yaml
+++ b/charts/cd4pe/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: puppet/continuous-delivery-for-puppet-enterprise
-  pullPolicy: Always # Keep up with the latest 3.x release
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "3.x"
 
@@ -41,11 +41,11 @@ service:
   loadBalancerSourceRanges:
   annotations: {}
   ports:
-    - port: 80 # container port 8080
+    - port: 80
       targetPort: http
       protocol: TCP
       name: http
-    - port: 443 # container port 8443
+    - port: 443
       targetPort: https
       protocol: TCP
       name: https
@@ -91,7 +91,7 @@ persistence:
 # Additional optionas are available in https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 postgresql:
   image:
-    tag: "9.6" # Pin to the 9.6 version of postgresql
+    tag: "9.6"
   postgresqlDatabase: "cd4pe"
   postgresqlUsername: "cd4pe"
   # postgresqlPassword can be set or a random password is generate and used


### PR DESCRIPTION
This commit adds an option to add a sidecar to the cd4pe pod. This can
enable the use of smee, with an example ripped directly from the jenkins
helm chart.